### PR TITLE
fix: make identity fully optional

### DIFF
--- a/examples/byo-identity/README.md
+++ b/examples/byo-identity/README.md
@@ -1,0 +1,20 @@
+This example illustrates the storage setup when using an already existing User Assigned Identity
+
+## Usage: default
+
+```hcl
+module "storage" {
+  source = "cloudnationhq/sa/azure"
+  version = "~> 1.0"
+
+  storage = {
+    name          = module.naming.storage_account.name_unique
+    location      = module.rg.groups.demo.location
+    resource_group = module.rg.groups.demo.name
+    identity = {
+      type = "UserAssigned"
+      identity_ids = [azurerm_user_assigned_identity.identity.id]
+    }
+  }
+}
+```

--- a/examples/byo-identity/main.tf
+++ b/examples/byo-identity/main.tf
@@ -1,0 +1,39 @@
+module "naming" {
+  source  = "cloudnationhq/naming/azure"
+  version = "~> 0.1"
+
+  suffix = ["demo", "dev"]
+}
+
+module "rg" {
+  source  = "cloudnationhq/rg/azure"
+  version = "~> 0.1"
+
+  groups = {
+    demo = {
+      name   = module.naming.resource_group.name
+      region = "westeurope"
+    }
+  }
+}
+
+module "storage" {
+  source  = "cloudnationhq/sa/azure"
+  version = "~> 1.0"
+
+  storage = {
+    name           = module.naming.storage_account.name_unique
+    location       = module.rg.groups.demo.location
+    resource_group = module.rg.groups.demo.name
+    identity       = {
+      type = "UserAssigned"
+      identity_ids = [azurerm_user_assigned_identity.identity.id]
+    }
+  }
+}
+
+resource "azurerm_user_assigned_identity" "identity" {
+  name                = module.naming.user_assigned_identity.name_unique
+  resource_group_name = module.rg.groups.demo.name
+  location            = module.rg.groups.demo.location
+}

--- a/examples/byo-identity/main.tf
+++ b/examples/byo-identity/main.tf
@@ -25,8 +25,8 @@ module "storage" {
     name           = module.naming.storage_account.name_unique
     location       = module.rg.groups.demo.location
     resource_group = module.rg.groups.demo.name
-    identity       = {
-      type = "UserAssigned"
+    identity = {
+      type         = "UserAssigned"
       identity_ids = [azurerm_user_assigned_identity.identity.id]
     }
   }

--- a/examples/byo-identity/terraform.tf
+++ b/examples/byo-identity/terraform.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = "~> 1.0"
+
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 3.114"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {}
+}

--- a/main.tf
+++ b/main.tf
@@ -250,8 +250,7 @@ resource "azurerm_storage_account" "sa" {
   }
 
   dynamic "identity" {
-    for_each = [lookup(var.storage, "identity", { type = "SystemAssigned", identity_ids = [] })]
-
+    for_each = try(var.storage.identity, null) != null ? { "default" = var.storage.identity } : {}
     content {
       type = identity.value.type
       identity_ids = concat(

--- a/main.tf
+++ b/main.tf
@@ -443,7 +443,6 @@ resource "azurerm_storage_management_policy" "mgmt_policy" {
 }
 
 resource "azurerm_user_assigned_identity" "identity" {
-  # for_each = contains(["UserAssigned", "SystemAssigned, UserAssigned"], try(var.storage.identity.type, "")) ? { "identity" = var.storage.identity } : {}
   for_each = lookup(var.storage, "identity", null) != null ? (
     (lookup(var.storage.identity, "type", null) == "UserAssigned" ||
     lookup(var.storage.identity, "type", null) == "SystemAssigned, UserAssigned") &&


### PR DESCRIPTION
## Description

This PR is solving the issue that was reported in issue #105.
It also includes an enhancement where a User Assigned Identity will not be created when identity_ids are specified (as this means that a already existing User Assigned Identity is being used and therefore there is no need to create a new one).
Added an example on how to use the module in combination with an existing identity.

## PR Checklist

- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have made corresponding changes to the documentation
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.

## Change Log

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking change (not backwards compatible with previous releases)

## Related Issue(s)
Fixes #105 
