### PR TITLE
feat: add missing management policies actions in base blob, snapshot and version

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -422,6 +422,7 @@ resource "azurerm_storage_management_policy" "mgmt_policy" {
         dynamic "base_blob" {
           for_each = try(rule.value.actions.base_blob, {})
 
+          # provider injects -1 in the plan, even when it is not specified in the config
           content {
             tier_to_cool_after_days_since_modification_greater_than        = try(base_blob.value.tier_to_cool_after_days_since_modification_greater_than, null)
             tier_to_cool_after_days_since_last_access_time_greater_than    = try(base_blob.value.tier_to_cool_after_days_since_last_access_time_greater_than, null)
@@ -429,7 +430,14 @@ resource "azurerm_storage_management_policy" "mgmt_policy" {
             tier_to_archive_after_days_since_last_access_time_greater_than = try(base_blob.value.tier_to_archive_after_days_since_last_access_time_greater_than, null)
             delete_after_days_since_modification_greater_than              = try(base_blob.value.delete_after_days_since_modification_greater_than, null)
             delete_after_days_since_last_access_time_greater_than          = try(base_blob.value.delete_after_days_since_last_access_time_greater_than, null)
-            auto_tier_to_hot_from_cool_enabled                             = try(base_blob.value.auto_tier_to_hot_from_cool_enabled, false)
+            auto_tier_to_hot_from_cool_enabled                             = contains(keys(base_blob.value), "auto_tier_to_hot_from_cool_enabled") ? base_blob.value.auto_tier_to_hot_from_cool_enabled : null
+            delete_after_days_since_creation_greater_than                  = try(base_blob.value.delete_after_days_since_creation_greater_than, null)
+            tier_to_cold_after_days_since_creation_greater_than            = try(base_blob.value.tier_to_cold_after_days_since_creation_greater_than, null)
+            tier_to_cool_after_days_since_creation_greater_than            = try(base_blob.value.tier_to_cool_after_days_since_creation_greater_than, null)
+            tier_to_archive_after_days_since_creation_greater_than         = try(base_blob.value.tier_to_archive_after_days_since_creation_greater_than, null)
+            tier_to_cold_after_days_since_modification_greater_than        = try(base_blob.value.tier_to_cold_after_days_since_modification_greater_than, null)
+            tier_to_cold_after_days_since_last_access_time_greater_than    = try(base_blob.value.tier_to_cold_after_days_since_last_access_time_greater_than, null)
+            tier_to_archive_after_days_since_last_tier_change_greater_than = try(base_blob.value.tier_to_archive_after_days_since_last_tier_change_greater_than, null)
           }
         }
 
@@ -437,9 +445,11 @@ resource "azurerm_storage_management_policy" "mgmt_policy" {
           for_each = try(rule.value.actions.snapshot, {})
 
           content {
-            change_tier_to_archive_after_days_since_creation = try(snapshot.value.change_tier_to_archive_after_days_since_creation, null)
-            change_tier_to_cool_after_days_since_creation    = try(snapshot.value.change_tier_to_cool_after_days_since_creation, null)
-            delete_after_days_since_creation_greater_than    = try(snapshot.value.delete_after_days_since_creation_greater_than, null)
+            change_tier_to_archive_after_days_since_creation               = try(snapshot.value.change_tier_to_archive_after_days_since_creation, null)
+            change_tier_to_cool_after_days_since_creation                  = try(snapshot.value.change_tier_to_cool_after_days_since_creation, null)
+            delete_after_days_since_creation_greater_than                  = try(snapshot.value.delete_after_days_since_creation_greater_than, null)
+            tier_to_archive_after_days_since_last_tier_change_greater_than = try(snapshot.value.tier_to_archive_after_days_since_last_tier_change_greater_than, null)
+            tier_to_cold_after_days_since_creation_greater_than            = try(snapshot.value.tier_to_cold_after_days_since_creation_greater_than, null)
           }
         }
 
@@ -447,9 +457,11 @@ resource "azurerm_storage_management_policy" "mgmt_policy" {
           for_each = try(rule.value.actions.version, {})
 
           content {
-            change_tier_to_archive_after_days_since_creation = try(version.value.change_tier_to_archive_after_days_since_creation, null)
-            change_tier_to_cool_after_days_since_creation    = try(version.value.change_tier_to_cool_after_days_since_creation, null)
-            delete_after_days_since_creation                 = try(version.value.delete_after_days_since_creation, null)
+            change_tier_to_archive_after_days_since_creation               = try(version.value.change_tier_to_archive_after_days_since_creation, null)
+            change_tier_to_cool_after_days_since_creation                  = try(version.value.change_tier_to_cool_after_days_since_creation, null)
+            delete_after_days_since_creation                               = try(version.value.delete_after_days_since_creation, null)
+            tier_to_cold_after_days_since_creation_greater_than            = try(version.value.tier_to_cold_after_days_since_creation_greater_than, null)
+            tier_to_archive_after_days_since_last_tier_change_greater_than = try(version.value.tier_to_archive_after_days_since_last_tier_change_greater_than, null)
           }
         }
       }


### PR DESCRIPTION
## Description

This PR adds missing management policies actions in base blob, snapshot and version

```
--- PASS: TestApplyAllParallel (0.00s)
    --- PASS: TestApplyAllParallel/queues (157.80s)
    --- PASS: TestApplyAllParallel/shares (167.05s)
    --- PASS: TestApplyAllParallel/byo-identity (168.74s)
    --- PASS: TestApplyAllParallel/default (176.02s)
    --- PASS: TestApplyAllParallel/file-systems (176.30s)
    --- PASS: TestApplyAllParallel/containers-blob (179.13s)
    --- PASS: TestApplyAllParallel/network-rules (216.58s)
    --- PASS: TestApplyAllParallel/management-policies (368.43s)
    --- PASS: TestApplyAllParallel/complete (375.01s)
    --- PASS: TestApplyAllParallel/private-endpoint (435.25s)
PASS
ok      github.com/cloudnationhq/terraform-azure-sa     435.675s
```

## PR Checklist

- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking change (not backwards compatible with previous releases)