### PR TITLE
fix: ignore syncsignature file share metadata everytime a file changes

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -327,6 +327,12 @@ resource "azurerm_storage_share" "sh" {
       }
     }
   }
+  lifecycle {
+    ignore_changes = [
+      # needed for file sync that changes the metadata every time when a file changes
+      metadata["syncsignature"],
+    ]
+  }
 }
 
 # tables


### PR DESCRIPTION
## Description

This PR ignores the property syncsignatures in the file share metadata, which is injected and chages every time a file changes when using filesync. The property comes from the azure backbone itself.

## PR Checklist

- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking change (not backwards compatible with previous releases)


## Related Issue(s)
Fixes #0000