### PR TITLE
fix: allow storage management policy rules without base_blob action rules

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -537,30 +537,29 @@ resource "azurerm_storage_management_policy" "mgmt_policy" {
       }
 
       actions {
-        base_blob {
-          tier_to_cool_after_days_since_modification_greater_than        = rule.value.actions.base_blob.tier_to_cool_after_days_since_modification_greater_than
-          tier_to_cool_after_days_since_last_access_time_greater_than    = rule.value.actions.base_blob.tier_to_cool_after_days_since_last_access_time_greater_than
-          tier_to_archive_after_days_since_modification_greater_than     = rule.value.actions.base_blob.tier_to_archive_after_days_since_modification_greater_than
-          tier_to_archive_after_days_since_last_access_time_greater_than = rule.value.actions.base_blob.tier_to_archive_after_days_since_last_access_time_greater_than
-          delete_after_days_since_modification_greater_than              = rule.value.actions.base_blob.delete_after_days_since_modification_greater_than
-          delete_after_days_since_last_access_time_greater_than          = rule.value.actions.base_blob.delete_after_days_since_last_access_time_greater_than
-          auto_tier_to_hot_from_cool_enabled                             = rule.value.actions.base_blob.auto_tier_to_hot_from_cool_enabled
-          delete_after_days_since_creation_greater_than                  = rule.value.actions.base_blob.delete_after_days_since_creation_greater_than
-          tier_to_archive_after_days_since_creation_greater_than         = rule.value.actions.base_blob.tier_to_archive_after_days_since_creation_greater_than
-          tier_to_cool_after_days_since_creation_greater_than            = rule.value.actions.base_blob.tier_to_cool_after_days_since_creation_greater_than
-          tier_to_cold_after_days_since_creation_greater_than            = rule.value.actions.base_blob.tier_to_cold_after_days_since_creation_greater_than
-          tier_to_cold_after_days_since_modification_greater_than        = rule.value.actions.base_blob.tier_to_cold_after_days_since_modification_greater_than
-          tier_to_cold_after_days_since_last_access_time_greater_than    = rule.value.actions.base_blob.tier_to_cold_after_days_since_last_access_time_greater_than
-          tier_to_archive_after_days_since_last_tier_change_greater_than = rule.value.actions.base_blob.tier_to_archive_after_days_since_last_tier_change_greater_than
+        dynamic "base_blob" {
+          for_each = anytrue([for k, v in try(rule.value.actions.base_blob, {}) : v != null && v != ""]) ? ["base_blob"] : []
+
+          content {
+            tier_to_cool_after_days_since_modification_greater_than        = rule.value.actions.base_blob.tier_to_cool_after_days_since_modification_greater_than
+            tier_to_cool_after_days_since_last_access_time_greater_than    = rule.value.actions.base_blob.tier_to_cool_after_days_since_last_access_time_greater_than
+            tier_to_archive_after_days_since_modification_greater_than     = rule.value.actions.base_blob.tier_to_archive_after_days_since_modification_greater_than
+            tier_to_archive_after_days_since_last_access_time_greater_than = rule.value.actions.base_blob.tier_to_archive_after_days_since_last_access_time_greater_than
+            delete_after_days_since_modification_greater_than              = rule.value.actions.base_blob.delete_after_days_since_modification_greater_than
+            delete_after_days_since_last_access_time_greater_than          = rule.value.actions.base_blob.delete_after_days_since_last_access_time_greater_than
+            auto_tier_to_hot_from_cool_enabled                             = rule.value.actions.base_blob.auto_tier_to_hot_from_cool_enabled
+            delete_after_days_since_creation_greater_than                  = rule.value.actions.base_blob.delete_after_days_since_creation_greater_than
+            tier_to_archive_after_days_since_creation_greater_than         = rule.value.actions.base_blob.tier_to_archive_after_days_since_creation_greater_than
+            tier_to_cool_after_days_since_creation_greater_than            = rule.value.actions.base_blob.tier_to_cool_after_days_since_creation_greater_than
+            tier_to_cold_after_days_since_creation_greater_than            = rule.value.actions.base_blob.tier_to_cold_after_days_since_creation_greater_than
+            tier_to_cold_after_days_since_modification_greater_than        = rule.value.actions.base_blob.tier_to_cold_after_days_since_modification_greater_than
+            tier_to_cold_after_days_since_last_access_time_greater_than    = rule.value.actions.base_blob.tier_to_cold_after_days_since_last_access_time_greater_than
+            tier_to_archive_after_days_since_last_tier_change_greater_than = rule.value.actions.base_blob.tier_to_archive_after_days_since_last_tier_change_greater_than
+          }
         }
 
         dynamic "snapshot" {
-          for_each = lookup(rule.value.actions, "snapshot", null) != null ? (
-            anytrue([
-              for k, v in lookup(rule.value.actions, "snapshot", {}) :
-              v != null && v != ""
-            ]) ? ["snapshot"] : []
-          ) : []
+          for_each = anytrue([for k, v in try(rule.value.actions.snapshot, {}) : v != null && v != ""]) ? ["snapshot"] : []
 
           content {
             change_tier_to_archive_after_days_since_creation               = rule.value.actions.snapshot.change_tier_to_archive_after_days_since_creation
@@ -572,12 +571,7 @@ resource "azurerm_storage_management_policy" "mgmt_policy" {
         }
 
         dynamic "version" {
-          for_each = lookup(rule.value.actions, "version", null) != null ? (
-            anytrue([
-              for k, v in lookup(rule.value.actions, "version", {}) :
-              v != null && v != ""
-            ]) ? ["version"] : []
-          ) : []
+          for_each = anytrue([for k, v in try(rule.value.actions.version, {}) : v != null && v != ""]) ? ["version"] : []
 
           content {
             change_tier_to_archive_after_days_since_creation               = rule.value.actions.version.change_tier_to_archive_after_days_since_creation


### PR DESCRIPTION
## Description

add rules without base_blob action generates the error:
```
Error: creating Storage Account Management Policy: (Management Policy Name "default" / Storage Account Name "xxxxx" / Resource Group "rgxxx"): unexpected status 400 (400 Bad Request) with error: InvalidManagementPolicyRule: ManagementPolicy rule default_lifecycle_rule is invalid. Invalid value for parameter : baseBlob For more information, see - https://aka.ms/managementpolicyexamples
```

example rule to reproduce (error occurs on apply)
```hcl
  rule {
    name    = "delete-old-blob-versions"
    enabled = true

    filters {
      blob_types = ["blockBlob"]
    }

    actions {
      versions {
       delete_after_days_since_creation = 30
      }
    }
  }
```


## PR Checklist

- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [ ] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have made corresponding changes to the documentation
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Change Log

Below please provide what should go into the changelog (if anything) 

<!-- Replace the changelog example below with your entry. One resource per line. -->

 * `azurerm_resource` - support for the `example` property


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking change (not backwards compatible with previous releases)


## Related Issue(s)
Fixes #0000
