### PR TITLE
fix: empty management policy when no rules are defined

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -522,7 +522,7 @@ resource "azurerm_storage_data_lake_gen2_path" "pa" {
 
 # management policies
 resource "azurerm_storage_management_policy" "mgmt_policy" {
-  for_each = try(var.storage.management_policy, null) != null ? { "default" = var.storage.management_policy } : {}
+  for_each = length(try(var.management_policy.rules, {})) > 0 ? { "default" = var.storage.management_policy } : {}
 
   storage_account_id = azurerm_storage_account.sa.id
 


### PR DESCRIPTION
## Description

when no rules are defined it wil still create the management policy, because its an optional object with defaults


## PR Checklist

- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have made corresponding changes to the documentation
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Change Log

Below please provide what should go into the changelog (if anything) 

<!-- Replace the changelog example below with your entry. One resource per line. -->

 * `azurerm_resource` - support for the `example` property


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking change (not backwards compatible with previous releases)


## Related Issue(s)
Fixes #0000
