### PR TITLE
fix: use of naming property without naming module 

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,13 +35,12 @@ The following requirements are needed by this module:
 
 The following providers are used by this module:
 
-- <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) (~> 4.0)
+- <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) (4.29.0)
 
 ## Resources
 
 The following resources are used by this module:
 
-- [azurerm_advanced_threat_protection.prot](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/advanced_threat_protection) (resource)
 - [azurerm_role_assignment.managed_identity](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) (resource)
 - [azurerm_storage_account.sa](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_account) (resource)
 - [azurerm_storage_account_local_user.lu](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_account_local_user) (resource)
@@ -91,7 +90,6 @@ object({
     dns_endpoint_type                 = optional(string, null)
     default_to_oauth_authentication   = optional(bool, false)
     tags                              = optional(map(string))
-    threat_protection                 = optional(bool, false)
     network_rules = optional(object({
       bypass                     = optional(list(string), ["None"])
       default_action             = optional(string, "Deny")

--- a/examples/queues/main.tf
+++ b/examples/queues/main.tf
@@ -35,7 +35,7 @@ module "storage" {
       }
 
       queues = {
-        q1 = {
+        qu1 = {
           metadata = {
             environment = "dev"
             owner       = "finance team"

--- a/examples/tables/README.md
+++ b/examples/tables/README.md
@@ -1,0 +1,1 @@
+This deploys storage tables

--- a/examples/tables/main.tf
+++ b/examples/tables/main.tf
@@ -26,10 +26,25 @@ module "storage" {
     location            = module.rg.groups.demo.location
     resource_group_name = module.rg.groups.demo.name
 
-    blob_properties = {
-      last_access_time_enabled = true
+    tables = {
+      tb1 = {
+        acl = {
+          acl1 = {
+            access_policy = {
+              permissions = "r"
+              start       = "2025-07-02T09:38:21Z"
+              expiry      = "2026-07-02T10:38:21Z"
+            }
+          }
+          acl2 = {
+            access_policy = {
+              permissions = "raud" #Read, Add, Update, Delete
+              start       = "2025-08-01T09:38:21Z"
+              expiry      = "2026-08-01T10:38:21Z"
+            }
+          }
+        }
+      }
     }
-
-    management_policy = local.management_policies
   }
 }

--- a/examples/tables/naming.tf
+++ b/examples/tables/naming.tf
@@ -1,0 +1,8 @@
+locals {
+  naming = {
+    # lookup outputs to have consistent naming
+    for type in local.naming_types : type => lookup(module.naming, type, {}).name
+  }
+
+  naming_types = ["storage_table"]
+}

--- a/examples/tables/terraform.tf
+++ b/examples/tables/terraform.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = "~> 1.0"
+
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 4.0"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {}
+}

--- a/main.tf
+++ b/main.tf
@@ -298,7 +298,8 @@ resource "azurerm_storage_container" "sc" {
 
   name = coalesce(
     var.storage.blob_properties.containers[each.key].name,
-    join("-", [var.naming.storage_container, each.key])
+    try(join("-", [var.naming.storage_container, each.key]), null),
+    each.key
   )
 
   storage_account_id                = azurerm_storage_account.sa.id
@@ -316,7 +317,9 @@ resource "azurerm_storage_queue" "sq" {
   ))
 
   name = coalesce(
-    each.value.name, join("-", [var.naming.storage_queue, each.key])
+    each.value.name,
+    try(join("-", [var.naming.storage_queue, each.key]), null),
+    each.key
   )
 
   storage_account_name = azurerm_storage_account.sa.name
@@ -411,7 +414,8 @@ resource "azurerm_storage_share" "sh" {
 
   name = coalesce(
     each.value.name,
-    join("-", [var.naming.storage_share, each.key])
+    try(join("-", [var.naming.storage_share, each.key]), null),
+    each.key
   )
 
   storage_account_id = azurerm_storage_account.sa.id
@@ -453,7 +457,12 @@ resource "azurerm_storage_table" "st" {
     var.storage.tables, {}
   )
 
-  name                 = try(each.value.name, join("-", [var.naming.storage_table, each.key]))
+  name = coalesce(
+    each.value.name,
+    try(join("-", [var.naming.storage_table, each.key]), null),
+    each.key
+  )
+
   storage_account_name = azurerm_storage_account.sa.name
 
   dynamic "acl" {
@@ -484,7 +493,9 @@ resource "azurerm_storage_data_lake_gen2_filesystem" "fs" {
   )
 
   name = coalesce(
-    each.value.name, join("-", [var.naming.storage_data_lake_gen2_filesystem, each.key])
+    each.value.name,
+    try(join("-", [var.naming.storage_data_lake_gen2_filesystem, each.key]), null),
+    each.key
   )
 
   storage_account_id       = azurerm_storage_account.sa.id

--- a/main.tf
+++ b/main.tf
@@ -644,11 +644,3 @@ resource "azurerm_role_assignment" "managed_identity" {
   skip_service_principal_aad_check       = var.storage.customer_managed_key.skip_service_principal_aad_check
   principal_type                         = "ServicePrincipal"
 }
-
-# advanced threat protection
-resource "azurerm_advanced_threat_protection" "prot" {
-  for_each = try(var.storage.threat_protection, false) ? { "threat_protection" = true } : {}
-
-  target_resource_id = azurerm_storage_account.sa.id
-  enabled            = true
-}

--- a/variables.tf
+++ b/variables.tf
@@ -27,7 +27,6 @@ variable "storage" {
     dns_endpoint_type                 = optional(string, null)
     default_to_oauth_authentication   = optional(bool, false)
     tags                              = optional(map(string))
-    threat_protection                 = optional(bool, false)
     network_rules = optional(object({
       bypass                     = optional(list(string), ["None"])
       default_action             = optional(string, "Deny")


### PR DESCRIPTION
## Description

- Added try() to 2nd (fallback) option for subresources, so that the coalesce function does not give an error.  
- Added 3rd option for naming, to use keys without the naming module. 
- Removed deprecated ATP function for storage account (see https://aka.ms/DF-Storage/NewPlanMigration)
- Added a Tables example


## PR Checklist

- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have made corresponding changes to the documentation
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking change (not backwards compatible with previous releases)


## Related Issue(s)
Fixes #174 #173 